### PR TITLE
feat: use dom-ready event for get() api

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -70,7 +70,8 @@ const messageHandlers = {
       userAgent: args.args.userAgent || pkg.description
     });
 
-    mainWindow.webContents.once('did-finish-load', data => {
+    // please refer to https://electronjs.org/docs/api/web-contents#event-dom-ready
+    mainWindow.webContents.once('dom-ready', data => {
       mainWindow.webContents.enableDeviceEmulation({
         screenPosition: 'mobile'
       });


### PR DESCRIPTION
For test case based on `DOM`, we can start testing after `dom-ready`

`did-finish-load` will be blocked by some pending requests
such as a `<img>` tag with invalid src url

![image](https://user-images.githubusercontent.com/2139038/51253105-6df65000-19d8-11e9-80bc-119c6c5ddd3a.png)


see https://electronjs.org/docs/api/web-contents#event-dom-ready