### PR TITLE
fix(electron): fix issue with excessive event listeners

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -50,11 +50,6 @@ IPC.prototype.send = async function(data) {
       reject(new errors.Timeout('Wait for message from the runner TIMEOUT.'));
     }, 60 * 1000);
 
-    this.proc.once('exit', code => {
-      resolve({ status: code });
-      clearTimeout(timer);
-    });
-
     this.proc.once('message', data => {
       resolve(data);
       clearTimeout(timer);


### PR DESCRIPTION
fix node warnings. this `exit` listener should not be necessary for each `send` event. we already have `this.proc.once('close')` on line 25.

tracing:
```
(node:94177) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [ChildProcess]. Use emitter.setMaxListeners() to increase limit
    at _addListener (events.js:390:17)
    at ChildProcess.addListener (events.js:406:10)
    at ChildProcess.once (events.js:437:8)
    at xxx/node_modules/macaca-electron/lib/ipc.js:53:15
    at new Promise (<anonymous>)
    at IPC.send (xxx/node_modules/macaca-electron/lib/ipc.js:41:10)
    at Electron.send (xxx/node_modules/macaca-electron/lib/macaca-electron.js:48:27)
    at Electron.sendCommand (xxx/node_modules/macaca-electron/lib/controllers.js:18:27)
    at Electron.sendJSCommand (xxx/node_modules/macaca-electron/lib/controllers.js:57:28)
    at Electron.controllers.getText (xxx/node_modules/macaca-electron/lib/controllers.js:194:30)
```