### PR TITLE
fix: 修复在调用 elements* 或者 elmentBy*OrNull API的时候如果元素为空需要等待5秒才返回结果

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -101,7 +101,13 @@ const findElementOrElements = async function(strategy, selector, ctx, many) {
       selector,
       atomsElement
     ]);
-    return _.size(result) > 0;
+    const size = _.size(result);
+
+    if (many) {
+      return size >= 0;
+    }
+
+    return size > 0;
   }
 
   try {

--- a/test/controllers.test.js
+++ b/test/controllers.test.js
@@ -100,7 +100,6 @@ describe('test/controllers.test.js', function() {
       assert.equal(divs.length, 2);
       var input = await driver.findElements('id', 'input');
       assert.equal(input.length, 1);
-      // need to wait for 5 seconds timeout
       var nonExistent = await driver.findElements('id', 'non-existent');
       assert.equal(nonExistent.length, 0);
     });


### PR DESCRIPTION
目前在调用
- elements*
- elementBy*OrNull

这类接口的时候，如果元素数组为空的话，则会一致停留等到超时结束后才会返回（目前是5秒）（超时时间在  [https://github.com/macacajs/macaca-electron/blob/master/lib/helper.js#L17](https://github.com/macacajs/macaca-electron/blob/master/lib/helper.js#L17) 中定义）

而针对专门判断为空的场景中，该等待时间超出合理预期。

因此在 `findElementOrElements` 中，针对 `many` 的场景下不需要强制判断结果元素数组的数量需要有值。